### PR TITLE
`new Buffer()` is DeprecationWarning issue

### DIFF
--- a/lib/attribute.js
+++ b/lib/attribute.js
@@ -71,7 +71,7 @@ Attribute.prototype.addValue = function addValue(val) {
   if (Buffer.isBuffer(val)) {
     this._vals.push(val);
   } else {
-    this._vals.push(new Buffer(val + '', _bufferEncoding(this.type)));
+    this._vals.push(Buffer.from(val + '', _bufferEncoding(this.type)));
   }
 };
 


### PR DESCRIPTION
(node:5993) [DEP0005] DeprecationWarning: Buffer() is deprecated due to security and usability issues. Please use the Buffer.alloc(), Buffer.allocUnsafe(), or Buffer.from() methods instead.
node 12.16.2 LTS version is Deprecated `new Buffer`

before : this._vals.push(new Buffer(val + '', _bufferEncoding(this.type)));
after : this._vals.push(Buffer.from(val + '', _bufferEncoding(this.type)));